### PR TITLE
Add discord banner to org readme

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -3,7 +3,7 @@
 PaperMC is a Minecraft Software organization focusing on improving the Minecraft ecosystem with faster and more secure software.
 
 **Quickstart:**
-- Learn more on [PaperMC.io](https://papermc.io)
+- Learn more on [PaperMC.io](https://papermc.io) or [get started](https://docs.papermc.io/paper/getting-started) now!
 - You can download Paper [here](https://papermc.io/downloads)
 - Support us by [sponsoring](https://papermc.io/sponsors) PaperMC
 - If you feel like talking to us, or need help you can either [join our Forum](https://forums.papermc.io/), or directly our Discord server:

--- a/profile/README.md
+++ b/profile/README.md
@@ -3,8 +3,7 @@
 PaperMC is a Minecraft Software organization focusing on improving the Minecraft ecosystem with faster and more secure software.
 
 **Quickstart:**
-- Learn more on [PaperMC.io](https://papermc.io) or [get started](https://docs.papermc.io/paper/getting-started) now!
-- You can download Paper [here](https://papermc.io/downloads)
+- Learn more and find downloads on [papermc.io](https://papermc.io)
 - Support us by donating through [OpenCollective](https://opencollective.com/papermc)
 - Join our community by [visiting our forums](https://forums.papermc.io/) or chatting on our Discord server:
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -6,7 +6,7 @@ PaperMC is a Minecraft Software organization focusing on improving the Minecraft
 - Learn more on [PaperMC.io](https://papermc.io) or [get started](https://docs.papermc.io/paper/getting-started) now!
 - You can download Paper [here](https://papermc.io/downloads)
 - Support us by donating through [OpenCollective](https://opencollective.com/papermc)
-- If you feel like talking to us, or need help you can either [join our Forum](https://forums.papermc.io/), or directly our Discord server:
+- Join our community by [visiting our forums](https://forums.papermc.io/) or chatting on our Discord server:
 
 <a href="https://discord.gg/papermc">
          <img alt="PaperMC Discord" src="https://discord.com/api/guilds/289587909051416579/widget.png?style=banner2">

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,3 +1,9 @@
 # PaperMC
 
 PaperMC is a Minecraft Software organization focusing on improving the Minecraft ecosystem with faster and more secure software.
+
+We have a Discord community server that anyone can join:
+
+<a href="https://discord.gg/papermc">
+         <img alt="PaperMC Discord" src="https://discord.com/api/guilds/289587909051416579/widget.png?style=banner2">
+</a>

--- a/profile/README.md
+++ b/profile/README.md
@@ -5,7 +5,7 @@ PaperMC is a Minecraft Software organization focusing on improving the Minecraft
 **Quickstart:**
 - Learn more on [PaperMC.io](https://papermc.io) or [get started](https://docs.papermc.io/paper/getting-started) now!
 - You can download Paper [here](https://papermc.io/downloads)
-- Support us by [sponsoring](https://papermc.io/sponsors) PaperMC
+- Support us by donating through [OpenCollective](https://opencollective.com/papermc)
 - If you feel like talking to us, or need help you can either [join our Forum](https://forums.papermc.io/), or directly our Discord server:
 
 <a href="https://discord.gg/papermc">

--- a/profile/README.md
+++ b/profile/README.md
@@ -2,7 +2,11 @@
 
 PaperMC is a Minecraft Software organization focusing on improving the Minecraft ecosystem with faster and more secure software.
 
-We have a Discord community server that anyone can join:
+**Quickstart:**
+- Learn more on [PaperMC.io](https://papermc.io)
+- You can download Paper [here](https://papermc.io/downloads)
+- Support us by [sponsoring](https://papermc.io/sponsors) PaperMC
+- If you feel like talking to us, or need help you can either [join our Forum](https://forums.papermc.io/), or directly our Discord server:
 
 <a href="https://discord.gg/papermc">
          <img alt="PaperMC Discord" src="https://discord.com/api/guilds/289587909051416579/widget.png?style=banner2">


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->
It's not really an issue but to make the possibility to get support easier by linking directly to Discord.

## Description
<!-- Please describe what this pull request does. -->
Inspired by [IntellectualSites](https://github.com/IntellectualSites) it adds a Discord banner, which redirects directly to the papermc discord when clicked on.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] New public fields and methods are annotated with `@since TODO`.
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
